### PR TITLE
Enable clearing stage 10

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,14 +133,14 @@ class MosquitoGame {
                 smokeSpeed: 2.3,
                 stageThreshold: 1500     // 血液35×43秒
             },
-            { 
-                stage: 10, 
+            {
+                stage: 10,
                 handSpeed: 4.0,          // 最終ステージ（激ムズ）
                 handPairs: 6,            // 手のペア6つ
                 smokeCount: 5,           // 煙5つ
                 smokeSize: 95,           // 大きな煙
                 smokeSpeed: 2.5,         // 速い煙の動き
-                stageThreshold: Infinity // クリア不要（サバイバル）
+                stageThreshold: 2000     // 大きな値でクリア可能に
             }
         ];
     }
@@ -453,7 +453,7 @@ class MosquitoGame {
         const stageProgress = this.totalBloodCollected * survivalTime;
         const config = this.stageConfigs[this.currentStage - 1];
         
-        if (stageProgress >= config.stageThreshold && this.currentStage < 10) {
+        if (stageProgress >= config.stageThreshold) {
             this.advanceStage();
         }
     }
@@ -465,13 +465,14 @@ class MosquitoGame {
         // ステージクリアエフェクト
         this.createStageAdvanceEffect();
         
-        // 難易度更新
-        this.updateDifficultyForStage();
-        
         // ステージ10でゲームクリア
         if (this.currentStage > 10) {
             this.gameComplete();
+            return;
         }
+
+        // 難易度更新
+        this.updateDifficultyForStage();
     }
     
     updateParticles() {


### PR DESCRIPTION
## Summary
- allow stage 10 to be cleared by setting a finite threshold
- always call `advanceStage()` once a stage threshold is met
- stop updating difficulty after stage 10 to trigger `gameComplete()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534193bf908324ba48ce6529f23fa4